### PR TITLE
added threshold for search score

### DIFF
--- a/code/backend/batch/utilities/helpers/EnvHelper.py
+++ b/code/backend/batch/utilities/helpers/EnvHelper.py
@@ -176,6 +176,8 @@ class EnvHelper:
             "1",
             "t",
         )
+        self.search_k_nearest_neighbors = int(os.getenv("AZURE_SEARCH_TOP_K_NEAREST_NEIGHBORS", 4))
+        self.search_score_threshold = float(os.getenv("AZURE_SEARCH_SCORE_THRESHOLD", 0.0))
 
     def should_use_data(self) -> bool:
         if (


### PR DESCRIPTION
Searching definitely should be improved:
'keywords' search gives very low and sometimes dubious search score. For instance: 'Javascript' keyword gives only 0.01 for 'Checkout'. 
Despite search returns 'Clarizen' project with an acceptable score by 'python' keyword, llm can't recognize that the project indeed utilizes python

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->